### PR TITLE
refactor: command interface

### DIFF
--- a/commands/commands.go
+++ b/commands/commands.go
@@ -23,9 +23,15 @@ type CommandStruct struct {
 	}
 }
 
-type ComponentHandler struct {
-	// component custom ID
-	ComponentID string
-	// component handler for button clicking and such
+// A single discord component
+type Component struct {
+	ComponentID      string
 	ComponentHandler HandlerFunc
+}
+
+// A discord slash command
+type Command interface {
+	Def() *discordgo.ApplicationCommand
+	Handler(sess *discordgo.Session, i *discordgo.InteractionCreate) (string, error)
+	Components() []Component
 }

--- a/commands/dd/dd.go
+++ b/commands/dd/dd.go
@@ -9,14 +9,16 @@ import (
 	"github.com/shawnyu5/debate_dragon_2.0/commands"
 )
 
-var CommandObj = commands.CommandStruct{
-	Name:    "dd",
-	Obj:     obj,
-	Handler: handler,
+type DD struct{}
+
+// Components implements commands.Command
+// this command does not have components
+func (DD) Components() []commands.Component {
+	return []commands.Component{}
 }
 
-// obj return a discord ApplicationCommand object defining this command
-func obj() *discordgo.ApplicationCommand {
+// Def implements commands.Command
+func (DD) Def() *discordgo.ApplicationCommand {
 	obj := &discordgo.ApplicationCommand{
 		Name:        "dd",
 		Description: "summon a dragon to burn your debate floes to the ground.",
@@ -32,8 +34,8 @@ func obj() *discordgo.ApplicationCommand {
 	return obj
 }
 
-// handler a handler function for debate dragon
-func handler(s *discordgo.Session, i *discordgo.InteractionCreate) (string, error) {
+// Handler implements commands.Command
+func (DD) Handler(sess *discordgo.Session, i *discordgo.InteractionCreate) (string, error) {
 	options := i.ApplicationCommandData().Options
 	optionMap := make(map[string]*discordgo.ApplicationCommandInteractionDataOption, len(options))
 	for _, opt := range options {
@@ -75,7 +77,7 @@ func handler(s *discordgo.Session, i *discordgo.InteractionCreate) (string, erro
 		log.Fatalln(err)
 	}
 
-	err = s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+	err = sess.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseChannelMessageWithSource,
 		Data: &discordgo.InteractionResponseData{
 			Files: []*discordgo.File{

--- a/commands/insult/insult.go
+++ b/commands/insult/insult.go
@@ -11,13 +11,15 @@ import (
 	"github.com/shawnyu5/debate_dragon_2.0/utils"
 )
 
-var CommandObj = commands.CommandStruct{
-	Name:    "insult",
-	Obj:     obj,
-	Handler: handler,
+type Insult struct{}
+
+// Components implements commands.Command
+func (Insult) Components() []commands.Component {
+	return nil
 }
 
-func obj() *discordgo.ApplicationCommand {
+// Def implements commands.Command
+func (Insult) Def() *discordgo.ApplicationCommand {
 	obj := &discordgo.ApplicationCommand{
 		Name:        "insult",
 		Description: "Ping someone to deliver a gut wrenching insult",
@@ -41,8 +43,8 @@ func obj() *discordgo.ApplicationCommand {
 	return obj
 }
 
-// handler a handler function for insult command
-func handler(sess *discordgo.Session, i *discordgo.InteractionCreate) (string, error) {
+// Handler implements commands.Command
+func (Insult) Handler(sess *discordgo.Session, i *discordgo.InteractionCreate) (string, error) {
 	optionsMap := utils.ParseUserOptions(sess, i)
 	user := optionsMap["user"].UserValue(sess)
 	if user.ID == "652511543845453855" {
@@ -52,7 +54,7 @@ func handler(sess *discordgo.Session, i *discordgo.InteractionCreate) (string, e
 	insult := GetInsult(user)
 
 	// send a normal insult if nothing is passed in, or if anonymous flag is set to false
-	if optionsMap["anonymous"] == nil || optionsMap["anonymous"].BoolValue() == false {
+	if optionsMap["anonymous"] == nil || !optionsMap["anonymous"].BoolValue() {
 		err := sess.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
 			Type: discordgo.InteractionResponseChannelMessageWithSource,
 			Data: &discordgo.InteractionResponseData{

--- a/commands/ivan/ivan.go
+++ b/commands/ivan/ivan.go
@@ -11,18 +11,15 @@ import (
 	"github.com/shawnyu5/debate_dragon_2.0/utils"
 )
 
-var CommandObj = commands.CommandStruct{
-	Name:    "ivan",
-	Obj:     obj,
-	Handler: handler,
+type Ivan struct{}
+
+// Components implements commands.Command
+func (Ivan) Components() []commands.Component {
+	return nil
 }
 
-type Emote struct {
-	Name         string `json:"name"`
-	FileLocation string `json:"fileLocation"`
-}
-
-func obj() *discordgo.ApplicationCommand {
+// Def implements commands.Command
+func (Ivan) Def() *discordgo.ApplicationCommand {
 	maxLength := float64(1000)
 	emotes := GetAllEmotes()
 	obj := &discordgo.ApplicationCommand{
@@ -59,7 +56,8 @@ func obj() *discordgo.ApplicationCommand {
 	return obj
 }
 
-func handler(sess *discordgo.Session, i *discordgo.InteractionCreate) (string, error) {
+// Handler implements commands.Command
+func (Ivan) Handler(sess *discordgo.Session, i *discordgo.InteractionCreate) (string, error) {
 	utils.DeferReply(sess, i.Interaction)
 	optionMap := utils.ParseUserOptions(sess, i)
 
@@ -128,6 +126,11 @@ func handler(sess *discordgo.Session, i *discordgo.InteractionCreate) (string, e
 		}
 	}
 	return "emote sent", nil
+}
+
+type Emote struct {
+	Name         string `json:"name"`
+	FileLocation string `json:"fileLocation"`
 }
 
 // FormatList formats an array of GuildBans into a bullet list

--- a/commands/manageIvan/manageIvan.go
+++ b/commands/manageIvan/manageIvan.go
@@ -26,36 +26,15 @@ var banJumpScareID = "ban_jump_scare"
 
 var ivanBanState = state{}
 
-var CommandObj = commands.CommandStruct{
-	Name:    "manageivan",
-	Obj:     obj,
-	Handler: commandHandler,
-	Components: []struct {
-		ComponentID      string
-		ComponentHandler commands.HandlerFunc
-	}{
-		{
-			ComponentID:      startBanProcessID,
-			ComponentHandler: StartBanningIvan,
-		},
-		{
-			ComponentID:      dontBanIvanID,
-			ComponentHandler: DontBanButton,
-		},
-		{
-			ComponentID:      banJumpScareID,
-			ComponentHandler: jumpScareBan,
-		},
-	},
-}
+type ManageIvan struct{}
 
-// obj returns the command object for `/manageivan` command
-func obj() *discordgo.ApplicationCommand {
+// Def implements commands.Command
+func (ManageIvan) Def() *discordgo.ApplicationCommand {
 	defaultManageMessagesPermission := int64(discordgo.PermissionManageMessages)
 	minValue := float64(5)
 
 	return &discordgo.ApplicationCommand{
-		Version:                  "1.1",
+		Version:                  "1.1.0",
 		Name:                     "manageivan",
 		DefaultMemberPermissions: &defaultManageMessagesPermission,
 		Description:              "Command to help the management of Ivan",
@@ -79,8 +58,26 @@ func obj() *discordgo.ApplicationCommand {
 	}
 }
 
-// commandHandler the commandHandler for `/manageivan` command
-func commandHandler(sess *discordgo.Session, i *discordgo.InteractionCreate) (string, error) {
+// Components implements commands.Command
+func (ManageIvan) Components() []commands.Component {
+	return []commands.Component{
+		{
+			ComponentID:      startBanProcessID,
+			ComponentHandler: StartBanningIvan,
+		},
+		{
+			ComponentID:      dontBanIvanID,
+			ComponentHandler: DontBanButton,
+		},
+		{
+			ComponentID:      banJumpScareID,
+			ComponentHandler: jumpScareBan,
+		},
+	}
+}
+
+// Handler implements commands.Command
+func (m ManageIvan) Handler(sess *discordgo.Session, i *discordgo.InteractionCreate) (string, error) {
 	optionsMap := utils.ParseUserOptions(sess, i)
 	countDown := optionsMap["countdown"]
 

--- a/commands/poll/poll.go
+++ b/commands/poll/poll.go
@@ -19,17 +19,10 @@ type VotesContainer = map[int][]discordgo.User
 // label which the data is stored in in db
 const DBLabel = "interviewVotes"
 
-var CommandObj = commands.CommandStruct{
-	Name:    "interview",
-	Obj:     obj,
-	Handler: handler,
-	Components: []struct {
-		ComponentID      string
-		ComponentHandler commands.HandlerFunc
-	}{},
-}
+type Poll struct{}
 
-func obj() *discordgo.ApplicationCommand {
+// Def implements commands.Command
+func (Poll) Def() *discordgo.ApplicationCommand {
 	var minValue = float64(0)
 	return &discordgo.ApplicationCommand{
 		Version:                  "1.0.0",
@@ -71,7 +64,8 @@ func obj() *discordgo.ApplicationCommand {
 	}
 }
 
-func handler(sess *discordgo.Session, i *discordgo.InteractionCreate) (string, error) {
+// Handler implements commands.Command
+func (Poll) Handler(sess *discordgo.Session, i *discordgo.InteractionCreate) (string, error) {
 	db := openDB()
 	defer db.Close()
 
@@ -201,6 +195,12 @@ func handler(sess *discordgo.Session, i *discordgo.InteractionCreate) (string, e
 		})
 		return "Default response", nil
 	}
+}
+
+// Components implements commands.Command.
+// no components for this command.
+func (Poll) Components() []commands.Component {
+	return []commands.Component{}
 }
 
 // openDB opens a connection to the local database

--- a/commands/rmp/rmp.go
+++ b/commands/rmp/rmp.go
@@ -12,6 +12,8 @@ import (
 
 const profSelectMenuID = "prof select menu"
 
+type Rmp struct{}
+
 type state struct {
 	// all seneca profs returned from RMP
 	AllSenecaProfs []ProfNode
@@ -21,22 +23,18 @@ type state struct {
 
 var rmpState = state{}
 
-var CommandObj = commands.CommandStruct{
-	Name:    "rmp",
-	Obj:     obj,
-	Handler: handler,
-	Components: []struct {
-		ComponentID      string
-		ComponentHandler commands.HandlerFunc
-	}{
+// Components implements commands.Command
+func (Rmp) Components() []commands.Component {
+	return []commands.Component{
 		{
 			ComponentID:      profSelectMenuID,
 			ComponentHandler: menuHandler,
 		},
-	},
+	}
 }
 
-func obj() *discordgo.ApplicationCommand {
+// Def implements commands.Command
+func (Rmp) Def() *discordgo.ApplicationCommand {
 	return &discordgo.ApplicationCommand{
 		Name:        "rmp",
 		Version:     "2.0.0",
@@ -53,7 +51,8 @@ func obj() *discordgo.ApplicationCommand {
 	}
 }
 
-func handler(sess *discordgo.Session, i *discordgo.InteractionCreate) (string, error) {
+// Handler implements commands.Command
+func (Rmp) Handler(sess *discordgo.Session, i *discordgo.InteractionCreate) (string, error) {
 	switch i.Type {
 	case discordgo.InteractionApplicationCommand:
 		options := utils.ParseUserOptions(sess, i)

--- a/commands/subForCarmen/subForCarmen.go
+++ b/commands/subForCarmen/subForCarmen.go
@@ -10,15 +10,7 @@ import (
 	"github.com/shawnyu5/debate_dragon_2.0/utils"
 )
 
-var CommandObj = commands.CommandStruct{
-	Name:    "subforcarmen",
-	Obj:     obj,
-	Handler: handler,
-	// Components: []struct {
-	// ComponentID      string
-	// ComponentHandler commands.HandlerFunc
-	// }{},
-}
+type SubForCarmen struct{}
 
 type State struct {
 	// time of the last notification
@@ -35,7 +27,13 @@ var CarmenState = State{
 	LastMessageTime:      time.Now(),
 }
 
-func obj() *discordgo.ApplicationCommand {
+// Components implements commands.Command
+func (SubForCarmen) Components() []commands.Component {
+	return nil
+}
+
+// Def implements commands.Command
+func (SubForCarmen) Def() *discordgo.ApplicationCommand {
 	c := utils.LoadConfig()
 	return &discordgo.ApplicationCommand{
 		GuildID:     c.SubForCarmen.GuildID,
@@ -57,12 +55,12 @@ func obj() *discordgo.ApplicationCommand {
 	}
 }
 
-func handler(sess *discordgo.Session, i *discordgo.InteractionCreate) (string, error) {
+// Handler implements commands.Command
+func (SubForCarmen) Handler(sess *discordgo.Session, i *discordgo.InteractionCreate) (string, error) {
 	userOptions := utils.ParseUserOptions(sess, i)
 	c := utils.LoadConfig()
 	// if subscribe, give user sub role
 	if userOptions["subscribe"].BoolValue() {
-		fmt.Printf("handler i.GuildID: %v\n", i.GuildID) // __AUTO_GENERATED_PRINT_VAR__
 		err := sess.GuildMemberRoleAdd(i.GuildID, i.Member.User.ID, c.SubForCarmen.SubscribersRoleID)
 		if err != nil {
 			return "", err

--- a/main.go
+++ b/main.go
@@ -8,7 +8,12 @@ import (
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/shawnyu5/debate_dragon_2.0/commands"
+	"github.com/shawnyu5/debate_dragon_2.0/commands/dd"
+	"github.com/shawnyu5/debate_dragon_2.0/commands/insult"
+	"github.com/shawnyu5/debate_dragon_2.0/commands/ivan"
 	"github.com/shawnyu5/debate_dragon_2.0/commands/manageIvan"
+	"github.com/shawnyu5/debate_dragon_2.0/commands/poll"
+	"github.com/shawnyu5/debate_dragon_2.0/commands/rmp"
 	subforcarmen "github.com/shawnyu5/debate_dragon_2.0/commands/subForCarmen"
 	generatedocs "github.com/shawnyu5/debate_dragon_2.0/generate_docs"
 	"github.com/shawnyu5/debate_dragon_2.0/middware"
@@ -46,12 +51,12 @@ var (
 	// array of all slash commands in this bot
 	allCommands = []commands.Command{
 		manageIvan.ManageIvan{},
-		// poll.CommandObj,
-		// dd.CommandObj,
-		// insult.CommandObj,
-		// ivan.CommandObj,
-		// rmp.CommandObj,
-		// subforcarmen.CommandObj,
+		poll.Poll{},
+		dd.DD{},
+		insult.Insult{},
+		ivan.Ivan{},
+		rmp.Rmp{},
+		subforcarmen.SubForCarmen{},
 	}
 
 	// array of slash command defs

--- a/main.go
+++ b/main.go
@@ -8,12 +8,7 @@ import (
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/shawnyu5/debate_dragon_2.0/commands"
-	"github.com/shawnyu5/debate_dragon_2.0/commands/dd"
-	"github.com/shawnyu5/debate_dragon_2.0/commands/insult"
-	"github.com/shawnyu5/debate_dragon_2.0/commands/ivan"
 	"github.com/shawnyu5/debate_dragon_2.0/commands/manageIvan"
-	"github.com/shawnyu5/debate_dragon_2.0/commands/poll"
-	"github.com/shawnyu5/debate_dragon_2.0/commands/rmp"
 	subforcarmen "github.com/shawnyu5/debate_dragon_2.0/commands/subForCarmen"
 	generatedocs "github.com/shawnyu5/debate_dragon_2.0/generate_docs"
 	"github.com/shawnyu5/debate_dragon_2.0/middware"
@@ -49,14 +44,14 @@ var (
 	defaultMemberPermissions int64 = discordgo.PermissionManageServer
 
 	// array of all slash commands in this bot
-	allCommands = []commands.CommandStruct{
-		poll.CommandObj,
-		dd.CommandObj,
-		insult.CommandObj,
-		ivan.CommandObj,
-		manageIvan.CommandObj,
-		rmp.CommandObj,
-		subforcarmen.CommandObj,
+	allCommands = []commands.Command{
+		manageIvan.ManageIvan{},
+		// poll.CommandObj,
+		// dd.CommandObj,
+		// insult.CommandObj,
+		// ivan.CommandObj,
+		// rmp.CommandObj,
+		// subforcarmen.CommandObj,
 	}
 
 	// array of slash command defs

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -194,10 +194,10 @@ func Contains(arr []discordgo.Guild, id string) bool {
 
 // GetCmdDefs get all slash command definitions.
 // returns: an array of slash command definitions.
-func GetCmdDefs(cmds []commands.CommandStruct) []*discordgo.ApplicationCommand {
+func GetCmdDefs(cmds []commands.Command) []*discordgo.ApplicationCommand {
 	slashCmds := make([]*discordgo.ApplicationCommand, 0)
 	for _, cmd := range cmds {
-		slashCmds = append(slashCmds, cmd.Obj())
+		slashCmds = append(slashCmds, cmd.Def())
 	}
 	return slashCmds
 }
@@ -205,20 +205,20 @@ func GetCmdDefs(cmds []commands.CommandStruct) []*discordgo.ApplicationCommand {
 // GetCmdHandler create a map of command name and their hander functions.
 // cmds: array of commands.
 // returns: a map of command name and their hander functions.
-func GetCmdHandler(cmds []commands.CommandStruct) map[string]commands.HandlerFunc {
+func GetCmdHandler(cmds []commands.Command) map[string]commands.HandlerFunc {
 	cmdHandlers := map[string]commands.HandlerFunc{}
 	for _, cmd := range cmds {
-		cmdHandlers[cmd.Name] = cmd.Handler
+		cmdHandlers[cmd.Def().Name] = cmd.Handler
 	}
 	return cmdHandlers
 }
 
 // GetComponentHandler creates a map of component name and the handler function.
 // return: a map of component ID and the handler function.
-func GetComponentHandler(cmds []commands.CommandStruct) map[string]commands.HandlerFunc {
+func GetComponentHandler(cmds []commands.Command) map[string]commands.HandlerFunc {
 	componentHandlers := map[string]commands.HandlerFunc{}
 	for _, cmd := range cmds {
-		for _, component := range cmd.Components {
+		for _, component := range cmd.Components() {
 			componentHandlers[component.ComponentID] = component.ComponentHandler
 		}
 	}


### PR DESCRIPTION
All command modules should implement an interface instead of exporting data with a struct. This leads to a lot less repeated data.
